### PR TITLE
Minor changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Run Clippy
+        run: cargo clippy
+
       - name: Push docker image release
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,8 @@ jobs:
         with:
           fetch-depth: 0
 
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Push docker image release
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
           push: false
           tags: cnieg/gitlab-tokens-exporter:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Run Clippy
+        run: cargo clippy
+
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79.0-alpine3.20 AS builder
+FROM rust:1.80.0-alpine3.20 AS builder
 
 RUN apk update && apk add --no-cache musl-dev
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,7 @@ async fn get_gitlab_tokens_handler(State(state): State<AppState>) -> (StatusCode
     }
 }
 
+#[allow(clippy::redundant_pub_crate)] // Because clippy is not happy with the tokio::select macro
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // An infinite stream of 'SIGTERM' signals.


### PR DESCRIPTION
- update rust to 1.80 (closes #12)
- do not build a multi-platform image when not on branch `main`
- run clippy in the build pipeline
- fix a clippy warning