### PR TITLE
OCI builder: use a debian image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
-FROM rust:1.84.0-alpine3.21 AS builder
+FROM rust:1.84.0-slim-bookworm AS builder
 
-RUN apk update && apk add --no-cache musl-dev
+ARG TARGETARCH
+
+RUN apt update && apt upgrade -y && apt install -y musl-dev musl-tools
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+		rustup target add x86_64-unknown-linux-musl ; \
+	elif [ "$TARGETARCH" = "arm64" ]; then \
+		rustup target add aarch64-unknown-linux-musl ; \
+	else \
+		echo "Unsupported architecture: $TARGETARCH" ; \
+		exit 1 ; \
+	fi
 
 WORKDIR /app
 
@@ -8,15 +18,25 @@ COPY Cargo.* ./
 
 # Downloading and building our dependencies (with an empty src/main.rs)
 RUN mkdir src && echo "fn main() {}" > src/main.rs
-RUN cargo build --release
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+		cargo build --release --target=x86_64-unknown-linux-musl ; \
+	elif [ "$TARGETARCH" = "arm64" ]; then \
+		cargo build --release --target=aarch64-unknown-linux-musl ; \
+	fi
 
 # Compiling the actual binary
 COPY src/ src
 RUN touch -a -m src/main.rs
-RUN cargo build --release
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+		cargo build --release --target=x86_64-unknown-linux-musl && \
+		mv /app/target/x86_64-unknown-linux-musl/release/gitlab-tokens-exporter /app/target/ ; \
+	elif [ "$TARGETARCH" = "arm64" ]; then \
+		cargo build --release --target=aarch64-unknown-linux-musl && \
+		mv /app/target/aarch64-unknown-linux-musl/release/gitlab-tokens-exporter /app/target/ ; \
+	fi
 
 # Final image
 FROM gcr.io/distroless/static-debian12:nonroot
-COPY --from=builder /app/target/release/gitlab-tokens-exporter .
+COPY --from=builder /app/target/gitlab-tokens-exporter .
 EXPOSE 3000
 ENTRYPOINT [ "./gitlab-tokens-exporter" ]


### PR DESCRIPTION
the github release workflow fails randomly with this type of error:

```
error: linking with `cc` failed: exit status: 4
```

```
note: cc: internal compiler error: Segmentation fault signal terminated program collect2
      Please submit a full bug report, with preprocessed source (by using -freport-bug).
      See <https://gitlab.alpinelinux.org/alpine/aports/-/issues> for instructions.
```

Opened issue : https://gitlab.alpinelinux.org/alpine/aports/-/issues/16813

Not sure if it is really caused by something alpine related, so testing with debian...