### PR TITLE
Add possibility to filter owned groups and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Optional environment variables :
 DATA_REFRESH_HOURS=6 (should be > 0 and <= 24 or else, it will be set to the default value: 6)
 ACCEPT_INVALID_CERTS=yes (DANGEROUS!!! disables HTTPS certificate validation when connecting to gitlab)
 RUST_LOG (to configure the tracing crate)
+OWNED_ENTITIES_ONLY=yes (checks only owned projects and groups - useful for gitlab.com)
 ```
 
 Run the following commands :

--- a/src/state_actor.rs
+++ b/src/state_actor.rs
@@ -263,7 +263,7 @@ pub async fn gitlab_tokens_actor(
     };
 
     // Checking OWNED_ENTITIES_ONLY env variable
-    let owned_entities_only  = match env::var("OWNED_ENTITIES_ONLY") {
+    let owned_entities_only = match env::var("OWNED_ENTITIES_ONLY") {
         Ok(value) => {
             if value == "yes" {
                 true

--- a/src/state_actor.rs
+++ b/src/state_actor.rs
@@ -89,14 +89,18 @@ async fn gitlab_get_data(
     let gitlab_token_clone1 = gitlab_token.clone();
     join_set.spawn(async move {
         let mut res = String::new();
-        let mut url;
-        if owned_entities_only {
-            url =
-                format!("https://{hostname_clone1}/api/v4/projects?per_page=100&archived=false&min_access_level=50");
-        } else {
-            url =
-                format!("https://{hostname_clone1}/api/v4/projects?per_page=100&archived=false");
-        }
+        #[expect(
+            clippy::as_conversions,
+            reason = "using 'as u8' is safe as long as gitlab::AccessLevel values are < 256"
+        )]
+        let mut url = format!(
+            "https://{hostname_clone1}/api/v4/projects?per_page=100&archived=false{}",
+            if owned_entities_only {
+                format!("&min_access_level={}", gitlab::AccessLevel::Owner as u8)
+            } else {
+                String::new()
+            }
+        );
         let projects =
             gitlab::Project::get_all(&http_client_clone1, url, &gitlab_token_clone1).await?;
         for project in projects {
@@ -122,14 +126,18 @@ async fn gitlab_get_data(
     let gitlab_token_clone2 = gitlab_token.clone();
     join_set.spawn(async move {
         let mut res = String::new();
-        let mut url;
-        if owned_entities_only {
-            url =
-                format!("https://{hostname_clone2}/api/v4/groups?per_page=100&archived=false&min_access_level=50");
-        } else {
-            url =
-                format!("https://{hostname_clone2}/api/v4/groups?per_page=100&archived=false");
-        }
+        #[expect(
+            clippy::as_conversions,
+            reason = "using 'as u8' is safe as long as gitlab::AccessLevel values are < 256"
+        )]
+        let mut url = format!(
+            "https://{hostname_clone2}/api/v4/groups?per_page=100&archived=false{}",
+            if owned_entities_only {
+                format!("&min_access_level={}", gitlab::AccessLevel::Owner as u8)
+            } else {
+                String::new()
+            }
+        );
         let groups = gitlab::Group::get_all(&http_client_clone2, url, &gitlab_token_clone2).await?;
         for group in groups {
             url = format!(


### PR DESCRIPTION
First of all thank You for creating this exporter!

### Use case
To use this exporter on managed GitLab (gitlab.com) instance to scan tokens in a group and all it's sub-groups and projects. `GITLAB_TOKEN` is set to the top group's access token with Owner role.

### Problem
When the exporter is run against managed GitLab instance it turned out that the original query scans all the public projects and groups which significantly increases runtime (i wasn't patient enough to wait for the first run - it was more than 15 minutes) and can hit [rate limits](https://docs.gitlab.com/administration/settings/rate_limit_on_projects_api/).

### Solution
Two solutions appeared to me as possible:
1. create env var to append arbitrary query params to url
2. create env var which modifies query params in a strict way

It seemed safer to go with the second option.

Then i tested parameters
- `owned=true` - only groups/projects with direct owner
- `min_access_level=50` - owner is direct or inherited

To achieve described use case i chose more generic approach with `min_access_level=50`. `owned=true` does not query for sub-groups and projects.

Tested only on managed GitLab instance with `OWNED_ENTITIES_ONLY` set to `yes` or unset.