### PR TITLE
fix: no line break before HELP comment in metric_str

### DIFF
--- a/src/prometheus_metrics.rs
+++ b/src/prometheus_metrics.rs
@@ -93,13 +93,13 @@ pub fn build(gitlab_token: &Token) -> Result<String, BoxedError> {
     write!(metric_str, "scopes=\"{token_scopes}\"")?;
 
     if let Some(expiration_date) = expires_at {
-        write!(
+        writeln!(
             metric_str,
             ",expires_at=\"{expiration_date}\"}} {}",
             (expiration_date - date_now).num_days()
         )?;
     } else {
-        write!(metric_str, "}} {DEFAULT_TOKEN_VALIDITY_DAYS}")?;
+        writeln!(metric_str, "}} {DEFAULT_TOKEN_VALIDITY_DAYS}")?;
     }
 
     info!("{}", metric_str.replace('"', "'").replace('\n', ""));


### PR DESCRIPTION
Currently, the exporter returns a list of metrics without a line break before the HELP comment, which results in lines 

`like: gitlab_token_days_until_expiry{...} -2221# HELP gitlab_token_days_until_expiry ...`

Prometheus considers the string invalid and cannot parse the metrics.

This fix adds a line break before the HELP comment, turning the line into 2 valid lines like: 

```
gitlab_token_days_until_expiry{...} -2221
# HELP gitlab_token_days_until_expiry ...
```