### PR TITLE
feat: filter user tokens by username

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Optional environment variables **not** set by default:
 ```
 ACCEPT_INVALID_CERTS=yes (DANGEROUS!!! disables HTTPS certificate validation when connecting to gitlab)
 OWNED_ENTITIES_ONLY=yes (checks only owned projects and groups - useful for gitlab.com)
+USERNAMES_FILTER=jenkins,renovate-bot (comma separated list of usernames)
 ```
 
 ## Getting Started

--- a/README_dockerhub.md
+++ b/README_dockerhub.md
@@ -29,6 +29,7 @@ Optional environment variables **not** set by default:
 ```
 ACCEPT_INVALID_CERTS=yes (DANGEROUS!!! disables HTTPS certificate validation when connecting to gitlab)
 OWNED_ENTITIES_ONLY=yes (checks only owned projects and groups - useful for gitlab.com)
+USERNAMES_FILTER=jenkins,renovate-bot (comma separated list of usernames)
 ```
 
 ## Getting Started

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
 //! Creates the exporter's [`Config`] in the static variable [`CONFIG`]
 
 use core::time::Duration;
-use std::{env, sync::LazyLock};
+use std::{collections::HashSet, env, sync::LazyLock};
 
 use anyhow::{Context as _, anyhow};
 use dotenvy::dotenv;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use crate::gitlab::connection::Connection;
 
@@ -40,6 +40,8 @@ pub struct Config {
     pub skip_non_expiring_tokens: bool,
     /// Skip users tokens if set to `true`
     pub skip_users_tokens: bool,
+    /// Filter users tokens by username
+    pub usernames_filter: Option<HashSet<String>>,
 }
 
 impl Config {
@@ -69,6 +71,13 @@ impl Config {
 
         // Checking SKIP_USERS_TOKENS env variable
         let skip_users_tokens = get_bool_or_false("SKIP_USERS_TOKENS")?;
+
+        // Checking USERNAMES_FILTER env variable
+        let usernames_filter = get_usernames_filter()?;
+
+        if skip_users_tokens && usernames_filter.is_some() {
+            warn!("USERNAMES_FILTER is ignored because SKIP_USERS_TOKENS is set to yes");
+        }
 
         // Checking SKIP_NON_EXPIRING_TOKENS env variable
         let skip_non_expiring_tokens = get_bool_or_false("SKIP_NON_EXPIRING_TOKENS")?;
@@ -107,6 +116,7 @@ impl Config {
             owned_entities_only,
             skip_non_expiring_tokens,
             skip_users_tokens,
+            usernames_filter,
         })
     }
 }
@@ -124,6 +134,29 @@ fn get_bool_or_false(env_var_name: &str) -> Result<bool, anyhow::Error> {
             env::VarError::NotPresent => Ok(false),
             env::VarError::NotUnicode(value) => Err(anyhow!(
                 "invalid value for '{env_var_name}': '{}'. expected 'yes' or 'no'.",
+                value.display()
+            )),
+        },
+    }
+}
+
+/// Returns the usernames configured in `USERNAMES_FILTER`,
+/// or `None` if the environment variable is not defined.
+fn get_usernames_filter() -> Result<Option<HashSet<String>>, anyhow::Error> {
+    match env::var("USERNAMES_FILTER") {
+        Ok(value) => {
+            let users = value
+                .split(',')
+                .map(|item| item.trim().to_owned())
+                .filter(|user| !user.is_empty())
+                .collect();
+
+            Ok(Some(users))
+        }
+        Err(err) => match err {
+            env::VarError::NotPresent => Ok(None),
+            env::VarError::NotUnicode(value) => Err(anyhow!(
+                "invalid value for 'USERNAMES_FILTER': '{}'.",
                 value.display()
             )),
         },

--- a/src/state_actor.rs
+++ b/src/state_actor.rs
@@ -175,14 +175,22 @@ async fn get_users_tokens_metrics() -> Result<String, anyhow::Error> {
         let user_ids: HashMap<_, _> = users
             .iter()
             .filter(|user| !human_users_re.is_match(&user.username))
+            .filter(|user| match &CONFIG.usernames_filter {
+                Some(filter) => filter.contains(&user.username),
+                None => true,
+            })
             .map(|user| (user.id, user.username.clone()))
             .collect();
 
         let mut personnal_access_tokens = PersonalAccessToken::get_all()
             .await
             .context("failed to get personnal access tokens")?;
-        // Retain personnal access tokens of human users
+        // Retain personnal access tokens of users listed in `user_ids`
         personnal_access_tokens.retain(|pat| user_ids.contains_key(&pat.user_id));
+
+        if CONFIG.usernames_filter.is_some() && personnal_access_tokens.is_empty() {
+            warn!("no token matched USERNAMES_FILTER");
+        }
 
         for personnal_access_token in personnal_access_tokens {
             if !(CONFIG.skip_non_expiring_tokens && personnal_access_token.expires_at.is_none()) {
@@ -230,7 +238,11 @@ async fn get_gitlab_data(sender: mpsc::Sender<Message>) {
     if CONFIG.skip_users_tokens {
         debug!("skipping users tokens as requested by SKIP_USERS_TOKENS env variable");
     } else {
-        debug!("not skipping users tokens as requested by SKIP_USERS_TOKENS env variable");
+        if CONFIG.usernames_filter.is_some() {
+            debug!("getting users tokens matching USERNAMES_FILTER");
+        } else {
+            debug!("getting all users tokens");
+        }
         set.spawn(get_users_tokens_metrics());
     }
 


### PR DESCRIPTION
closed issue https://github.com/cnieg/gitlab-tokens-exporter/issues/195

Tested with :
```
SKIP_USERS_TOKENS=yes
no GITLAB_USERS_FILTER
```
==> all users tokens are skipped

```
SKIP_USERS_TOKENS=yes
GITLAB_USERS_FILTER=...
```
==> all users tokens are skipped but warning "GITLAB_USERS_FILTER is ignored because SKIP_USERS_TOKENS is set to yes"

```
SKIP_USERS_TOKENS=no
GITLAB_USERS_FILTER=x,y,z
```
==> all users tokens are skipped except for x, y and z users

```
SKIP_USERS_TOKENS=no
no GITLAB_USERS_FILTER
```
==> all users tokens are collected

For CNIEG needs, we have to set :
```
SKIP_USERS_TOKENS=no
GITLAB_USERS_FILTER=gama,INTG,jenkins,renovate-bot,svc_hopper
```