### PR TITLE
chore: update github runner image

### DIFF
--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   release:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.event.pull_request.draft == false
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release-plz-release:
     if: ${{ github.repository_owner == 'cnieg' }}
     name: Release-plz release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write
@@ -90,7 +90,7 @@ jobs:
   release-plz-pr:
     if: ${{ github.repository_owner == 'cnieg' }}
     name: Release-plz PR
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
We should wait for Rust version 1.98.1 (cf https://github.com/actions/runner-images/pull/14690) to be available in this image (ubuntu-26.04) before merging this.